### PR TITLE
Modify hparams readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ This step is exactly the same as in Google/Electra document. You can refer this 
 python run_pretraining.py \
     --data-dir data \
     --model-name electra_small_japanese \
-    --hparams '{"debug": false, "do_train": true, "do_eval": false, "vocab_file": "data/vocab.txt", "model_sentencepiece_path": "model_sentence_piece/wiki-ja.vocab", "model_size": "small", "vocab_size": 32000, "max_seq_length": 512, "num_train_steps": 1000000, "train_batch_size": 64}'
+    --hparams '{"debug": false, "do_train": true, "do_eval": false, "vocab_file": "data/vocab.txt", "model_sentencepiece_path": "model_sentence_piece/wiki-ja.model", "model_size": "small", "vocab_size": 32000, "max_seq_length": 512, "num_train_steps": 1000000, "train_batch_size": 64}'
 ```

--- a/pretrain/pretrain_helpers.py
+++ b/pretrain/pretrain_helpers.py
@@ -153,7 +153,7 @@ def mask(config: configure_pretraining.PretrainingConfig,
 
     # Find indices where masking out a token is allowed
     vocab = tokenization.FullTokenizer(
-        config.model_sentencepiece_path, config.vocab_file, do_lower_case=config.do_lower_case).vocab
+        config.vocab_file, config.model_sentencepiece_path, do_lower_case=config.do_lower_case).vocab
     candidates_mask = _get_candidates_mask(inputs, vocab, disallow_from_mask)
 
     # Set the number of tokens to mask out per example


### PR DESCRIPTION
I think that model_sentence_piece_path in hparams for run_pretraining.py is wrong. I modified from "wiki-ja.vocab" to "wiki-ja.model".